### PR TITLE
Improve bazel JUnit5 integration with IntelliJ

### DIFF
--- a/junit5-jupiter-starter-bazel/bazeljunit5/README.md
+++ b/junit5-jupiter-starter-bazel/bazeljunit5/README.md
@@ -38,9 +38,37 @@ and put the XML test report in a file `TEST-*.xml` in the reports dir.
 and rename the file `TEST-*.xml` to XML_OUTPUT_FILE.
 
 ### How
+* Import this repository into your bazel `WORKSPACE` file
+
+```python
+###########
+# JUnit 5 #
+###########
+
+git_repository(
+    name = "bazel_junit5",
+    # branch = "master",
+    commit = "<INSERT_COMMIT_SHA>",
+    remote = "https://github.com/junit-team/junit5-samples.git",
+)
+
+load("@bazel_junit5//junit5-jupiter-starter-bazel:junit5.bzl", "junit_jupiter_java_repositories", "junit_platform_java_repositories")
+
+JUNIT_JUPITER_VERSION = "5.6.2"
+JUNIT_PLATFORM_VERSION = "1.6.2"
+
+junit_jupiter_java_repositories(
+    version = JUNIT_JUPITER_VERSION,
+)
+
+junit_platform_java_repositories(
+    version = JUNIT_PLATFORM_VERSION,
+)
+```
+
 * Set the main_class and deps for java_junit5_test
 ```python
-load("//:junit5.bzl", "java_junit5_test")
+load("@bazel_junit5//junit5-jupiter-starter-bazel:junit5.bzl", "java_junit5_test")
 
 java_junit5_test(
     # ...

--- a/junit5-jupiter-starter-bazel/bazeljunit5/src/main/java/com/flexport/bazeljunit5/BUILD
+++ b/junit5-jupiter-starter-bazel/bazeljunit5/src/main/java/com/flexport/bazeljunit5/BUILD
@@ -18,6 +18,6 @@ java_library(
 
         # External dependencies
         "@org_junit_platform_junit_platform_commons//:org_junit_platform_junit_platform_commons",
-        "@org_junit_platform_junit_platform_console//:org_junit_platform_junit_platform_console"
+        "@org_junit_platform_junit_platform_console//:org_junit_platform_junit_platform_console",
     ],
 )

--- a/junit5-jupiter-starter-bazel/bazeljunit5/src/main/java/com/flexport/bazeljunit5/BazelJUnit5ConsoleLauncher.java
+++ b/junit5-jupiter-starter-bazel/bazeljunit5/src/main/java/com/flexport/bazeljunit5/BazelJUnit5ConsoleLauncher.java
@@ -103,7 +103,7 @@ public class BazelJUnit5ConsoleLauncher {
     List<Document> xmlDocuments = new ArrayList<>();
     for (File file : files) {
       Document xmlDocument = loadXmlDocument(file);
-      removeParanthesesFromTestCaseNames(xmlDocument);
+      removeParenthesesFromTestCaseNames(xmlDocument);
       xmlDocuments.add(xmlDocument);
     }
 
@@ -135,7 +135,7 @@ public class BazelJUnit5ConsoleLauncher {
    * Having parantheses in the test case names seems to cause issues in IntelliJ - `jump to source`
    * doesn't work in test explorer. This method simply trims everything following the test method name.
    */
-  private static void removeParanthesesFromTestCaseNames(Document document) {
+  private static void removeParenthesesFromTestCaseNames(Document document) {
     NodeList nodeList = document.getElementsByTagName("testcase");
     for (int i = 0; i < nodeList.getLength(); i++) {
       Node node = nodeList.item(i);

--- a/junit5-jupiter-starter-bazel/bazeljunit5/src/main/java/com/flexport/bazeljunit5/BazelJUnit5ConsoleLauncher.java
+++ b/junit5-jupiter-starter-bazel/bazeljunit5/src/main/java/com/flexport/bazeljunit5/BazelJUnit5ConsoleLauncher.java
@@ -153,7 +153,6 @@ public class BazelJUnit5ConsoleLauncher {
       }
 
       nameAttribute.setNodeValue(testCaseName);
-      System.out.println(node.getNodeName());
     }
   }
 

--- a/junit5-jupiter-starter-bazel/bazeljunit5/src/main/java/com/flexport/bazeljunit5/BazelJUnit5ConsoleLauncher.java
+++ b/junit5-jupiter-starter-bazel/bazeljunit5/src/main/java/com/flexport/bazeljunit5/BazelJUnit5ConsoleLauncher.java
@@ -132,7 +132,7 @@ public class BazelJUnit5ConsoleLauncher {
   }
 
   /**
-   * Having parantheses in the test case names seems to cause issues in IntelliJ - `jump to source`
+   * Having parentheses in the test case names seems to cause issues in IntelliJ - `jump to source`
    * doesn't work in test explorer. This method simply trims everything following the test method name.
    */
   private static void removeParenthesesFromTestCaseNames(Document document) {

--- a/junit5-jupiter-starter-bazel/bazeljunit5/src/main/java/com/flexport/bazeljunit5/BazelJUnit5ConsoleLauncher.java
+++ b/junit5-jupiter-starter-bazel/bazeljunit5/src/main/java/com/flexport/bazeljunit5/BazelJUnit5ConsoleLauncher.java
@@ -118,7 +118,8 @@ public class BazelJUnit5ConsoleLauncher {
       }
     }
 
-    addMessageAttributeToFailureNodes(mergedXmlOutput.getElementsByTagName("failure"));
+    addEmptyMessageAttributeToNodes(mergedXmlOutput.getElementsByTagName("failure"));
+    addEmptyMessageAttributeToNodes(mergedXmlOutput.getElementsByTagName("skipped"));
     return mergedXmlOutput;
   }
 
@@ -152,10 +153,10 @@ public class BazelJUnit5ConsoleLauncher {
   }
 
   /**
-   * Adds an empty 'message' attribute to failure nodes in test cases. This was needed to get
-   * IntelliJ to show failed tests correctly.
+   * Adds an empty 'message' attribute to specified nodes in test cases. This was needed to get
+   * IntelliJ to show failed/ignored tests correctly.
    */
-  private static void addMessageAttributeToFailureNodes(NodeList failureNodes) {
+  private static void addEmptyMessageAttributeToNodes(NodeList failureNodes) {
     for (int i = 0; i < failureNodes.getLength(); ++i) {
       Node node = failureNodes.item(i);
       ((Element) node).setAttribute("message", "");

--- a/junit5-jupiter-starter-bazel/bazeljunit5/src/main/java/com/flexport/bazeljunit5/BazelJUnit5ConsoleLauncher.java
+++ b/junit5-jupiter-starter-bazel/bazeljunit5/src/main/java/com/flexport/bazeljunit5/BazelJUnit5ConsoleLauncher.java
@@ -157,6 +157,10 @@ public class BazelJUnit5ConsoleLauncher {
     }
   }
 
+  /**
+   * Adds an empty 'message' attribute to failure nodes in test cases. This was needed to get
+   * IntelliJ to show failed tests correctly.
+   */
   private static void addMessageAttributeToFailureNodes(NodeList failureNodes) {
     for (int i = 0; i < failureNodes.getLength(); ++i) {
       Node node = failureNodes.item(i);

--- a/junit5-jupiter-starter-bazel/bazeljunit5/src/main/java/com/flexport/bazeljunit5/BazelJUnit5ConsoleLauncher.java
+++ b/junit5-jupiter-starter-bazel/bazeljunit5/src/main/java/com/flexport/bazeljunit5/BazelJUnit5ConsoleLauncher.java
@@ -142,10 +142,25 @@ public class BazelJUnit5ConsoleLauncher {
     for (int i = 0; i < nodeList.getLength(); i++) {
       Node node = nodeList.item(i);
       Node nameAttribute = node.getAttributes().getNamedItem("name");
-      String testCaseName = nameAttribute.getNodeValue().split("\\(")[0];
+      String testCaseName =
+          nameAttribute.getNodeValue().split("\\(")[0];
+      String testDisplayName = getTestCaseDisplayName(node);
+      if (testDisplayName.trim().startsWith("[")) {
+        testCaseName += testDisplayName;
+      }
+
       nameAttribute.setNodeValue(testCaseName);
       System.out.println(node.getNodeName());
     }
+  }
+
+  private static String getTestCaseDisplayName(Node testCase) {
+    String systemOutText = testCase.getFirstChild().getNextSibling().getFirstChild().getNodeValue();
+    final String displayNameTag = "display-name:";
+    String displayName = systemOutText
+        .substring(systemOutText.indexOf(displayNameTag) + displayNameTag.length());
+    displayName = displayName.replaceAll("\\(,\\)", "");
+    return displayName;
   }
 
   private static void writeXmlOutputToFile(Document xmlDocument, String fileName)

--- a/junit5-jupiter-starter-bazel/bazeljunit5/src/main/java/com/flexport/bazeljunit5/BazelJUnit5ConsoleLauncher.java
+++ b/junit5-jupiter-starter-bazel/bazeljunit5/src/main/java/com/flexport/bazeljunit5/BazelJUnit5ConsoleLauncher.java
@@ -16,7 +16,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -308,12 +307,8 @@ public class BazelJUnit5ConsoleLauncher {
    */
   private static HashSet<String> getMethodNames(String testFilterMethodsSubstring) {
     testFilterMethodsSubstring = testFilterMethodsSubstring.replace("(", "").replace(")", "");
-    HashSet<String> methodNames = new HashSet<>();
-    Collections.addAll(methodNames,
-        Arrays.stream(testFilterMethodsSubstring.split("[,|]")).distinct()
-            .map(s -> s.split("[ \\[\\\\]")[0])
-            .collect(
-                Collectors.joining()));
+    HashSet<String> methodNames = Arrays.stream(testFilterMethodsSubstring.split("[,|]")).distinct()
+        .map(s -> s.split("[ \\[\\\\]")[0]).collect(Collectors.toCollection(HashSet::new));
     return methodNames;
   }
 

--- a/junit5-jupiter-starter-bazel/bazeljunit5/src/main/java/com/flexport/bazeljunit5/BazelJUnit5ConsoleLauncher.java
+++ b/junit5-jupiter-starter-bazel/bazeljunit5/src/main/java/com/flexport/bazeljunit5/BazelJUnit5ConsoleLauncher.java
@@ -84,11 +84,6 @@ public class BazelJUnit5ConsoleLauncher {
       return;
     }
 
-    if (files.length > 1) {
-      // The XML output file is not found.
-      System.err.println("More than one XML output file is found");
-    }
-
     try {
       Document mergedXmlOutput = mergeTestResultXmls(files);
       writeXmlOutputToFile(mergedXmlOutput, requiredPath.toString());

--- a/junit5-jupiter-starter-bazel/bazeljunit5/src/main/java/com/flexport/bazeljunit5/BazelJUnit5ConsoleLauncher.java
+++ b/junit5-jupiter-starter-bazel/bazeljunit5/src/main/java/com/flexport/bazeljunit5/BazelJUnit5ConsoleLauncher.java
@@ -123,6 +123,7 @@ public class BazelJUnit5ConsoleLauncher {
       }
     }
 
+    addMessageAttributeToFailureNodes(mergedXmlOutput.getElementsByTagName("failure"));
     return mergedXmlOutput;
   }
 
@@ -153,6 +154,13 @@ public class BazelJUnit5ConsoleLauncher {
 
       nameAttribute.setNodeValue(testCaseName);
       System.out.println(node.getNodeName());
+    }
+  }
+
+  private static void addMessageAttributeToFailureNodes(NodeList failureNodes) {
+    for (int i = 0; i < failureNodes.getLength(); ++i) {
+      Node node = failureNodes.item(i);
+      ((Element) node).setAttribute("message", "");
     }
   }
 

--- a/junit5-jupiter-starter-bazel/bazeljunit5/src/main/java/com/flexport/bazeljunit5/BazelJUnit5ConsoleLauncher.java
+++ b/junit5-jupiter-starter-bazel/bazeljunit5/src/main/java/com/flexport/bazeljunit5/BazelJUnit5ConsoleLauncher.java
@@ -134,8 +134,8 @@ public class BazelJUnit5ConsoleLauncher {
   }
 
   /**
-   * Having parantheses in the test case names seems to cause issues in IntelliJ - `jump to source` doesn't work in test explorer.
-   * This method simply trims everything following the test method name.
+   * Having parantheses in the test case names seems to cause issues in IntelliJ - `jump to source`
+   * doesn't work in test explorer. This method simply trims everything following the test method name.
    */
   private static void removeParanthesesFromTestCaseNames(Document document) {
     NodeList nodeList = document.getElementsByTagName("testcase");
@@ -144,6 +144,8 @@ public class BazelJUnit5ConsoleLauncher {
       Node nameAttribute = node.getAttributes().getNamedItem("name");
       String testCaseName =
           nameAttribute.getNodeValue().split("\\(")[0];
+
+      // Appends display name to test case name in the case of parameterized tests (a bit hacky)
       String testDisplayName = getTestCaseDisplayName(node);
       if (testDisplayName.trim().startsWith("[")) {
         testCaseName += testDisplayName;
@@ -154,6 +156,11 @@ public class BazelJUnit5ConsoleLauncher {
     }
   }
 
+  /**
+   * Every <testcase> node in the xml has a <system-out> node which has some additional info including
+   * a friendly 'display-name'. This is useful especially for parameterized tests to show the params used
+   * in individual runs of the test-case.
+   */
   private static String getTestCaseDisplayName(Node testCase) {
     String systemOutText = testCase.getFirstChild().getNextSibling().getFirstChild().getNodeValue();
     final String displayNameTag = "display-name:";

--- a/junit5-jupiter-starter-bazel/bazeljunit5/src/test/java/com/flexport/bazeljunit5/BazelJUnit5ConsoleLauncherTest.java
+++ b/junit5-jupiter-starter-bazel/bazeljunit5/src/test/java/com/flexport/bazeljunit5/BazelJUnit5ConsoleLauncherTest.java
@@ -10,9 +10,6 @@
 
 package com.flexport.bazeljunit5;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -23,22 +20,30 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 class BazelJUnit5ConsoleLauncherTest {
 
   static class TestClass {
-    void testMethod() {}
+    void testMethod() {
+    }
 
-    void testMethod(int a) {}
+    void testMethod(int a) {
+    }
 
-    void testMethod(int a, Integer b) {}
+    void testMethod(int a, Integer b) {
+    }
 
-    void testMethod1() {}
+    void testMethod1() {
+    }
   }
 
   @ParameterizedTest
@@ -46,8 +51,6 @@ class BazelJUnit5ConsoleLauncherTest {
       value = {
           ",false,",
           "foo.xml,false,",
-          "TEST-foo.xml,false,TEST-foo.xml",
-          "foo.xml|TEST-bar.xml|TEST-baz.xml,false,TEST-bar.xml|TEST-baz.xml",
           "foo.xml|TEST-bar.xml|TEST-baz.xml,true,",
       })
   void fixXmlOutputFile(String files, boolean isXmlOutputFileEmpty, String expectedContents)
@@ -159,8 +162,8 @@ class BazelJUnit5ConsoleLauncherTest {
         expectedOptionsText.isEmpty()
             ? Arrays.asList()
             : Arrays.stream(expectedOptionsText.split("\\|"))
-            .map(s -> s.replace("{class}", TestClass.class.getName()))
-            .collect(Collectors.toList());
+                .map(s -> s.replace("{class}", TestClass.class.getName()))
+                .collect(Collectors.toList());
 
     assertThat(options).hasSameElementsAs(expectedOptions);
   }

--- a/junit5-jupiter-starter-bazel/bazeljunit5/src/test/java/com/flexport/bazeljunit5/BazelJUnit5ConsoleLauncherTest.java
+++ b/junit5-jupiter-starter-bazel/bazeljunit5/src/test/java/com/flexport/bazeljunit5/BazelJUnit5ConsoleLauncherTest.java
@@ -147,7 +147,6 @@ class BazelJUnit5ConsoleLauncherTest {
               + "--select-method={class}#testMethod()|"
               + "--select-method={class}#testMethod(int)|"
               + "--select-method={class}#testMethod(int, java.lang.Integer)",
-          "{class}#testMethod(); --select-method={class}#testMethod()",
           "{class}#testMethod1; --select-method={class}#testMethod1()",
       },
       delimiter = ';')


### PR DESCRIPTION
## Overview

Building on https://github.com/junit-team/junit5-samples/pull/133 to improve the integration with IntelliJ. Fixes/Improves the following:
1. Report test results from both JUnit Jupiter and Vintage
2. 'Jump to source' from test results explorer works. 
3. Tries to improve reporting of parameterised test results by including param values in the display name, works in some cases.
4. Some improvements to rerunning failed tests - handle parameterized tests, methods from multiple classes etc.
---
I hereby agree to the terms of the JUnit Contributor License Agreement.
